### PR TITLE
skipWasm renamed to wasmWitness

### DIFF
--- a/circomkit.json
+++ b/circomkit.json
@@ -1,1 +1,1 @@
-{"cWitness": true, "skipWasm": true}
+{"cWitness": true, "wasmWitness": false}


### PR DESCRIPTION
No longer using a forked circomkit in the compiler pipeline https://github.com/circuitscan/circom-pipeline/commit/3080441a7a5c27cdcf94bd6048a110c3c9b56161 but the property name has changed according PR review https://github.com/erhant/circomkit/pull/121

Be sure to use new circuitscan CLI npm @ 0.1.11